### PR TITLE
Add Terraform infrastructure and CI/CD scaffolding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build and Push Container Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  ARTIFACT_REPOSITORY: ${{ secrets.ARTIFACT_REPOSITORY }}
+  SERVICE_NAME: ${{ secrets.SERVICE_NAME }}
+  IMAGE_BASE: ${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ARTIFACT_REPOSITORY }}/${{ secrets.SERVICE_NAME }}
+  IMAGE_TAG: ${{ github.sha }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_BUILD_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker authentication
+        run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        run: docker build -t $IMAGE_BASE:$IMAGE_TAG .
+
+      - name: Push image
+        run: |
+          docker push $IMAGE_BASE:$IMAGE_TAG
+          docker tag $IMAGE_BASE:$IMAGE_TAG $IMAGE_BASE:latest
+          docker push $IMAGE_BASE:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  ARTIFACT_REPOSITORY: ${{ secrets.ARTIFACT_REPOSITORY }}
+  SERVICE_NAME: ${{ secrets.SERVICE_NAME }}
+  CLOUD_RUN_REGION: ${{ secrets.CLOUD_RUN_REGION }}
+  IMAGE: ${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ARTIFACT_REPOSITORY }}/${{ secrets.SERVICE_NAME }}:${{ github.sha }}
+
+jobs:
+  deploy-staging:
+    name: Deploy to staging
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Deploy service
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ format('{0}-staging', secrets.SERVICE_NAME) }}
+          image: ${{ env.IMAGE }}
+          region: ${{ env.CLOUD_RUN_REGION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          service_account: ${{ secrets.CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT }}
+          allow_unauthenticated: true
+
+  deploy-production:
+    name: Deploy to production
+    needs: deploy-staging
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: production
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Deploy service
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ format('{0}-prod', secrets.SERVICE_NAME) }}
+          image: ${{ env.IMAGE }}
+          region: ${{ env.CLOUD_RUN_REGION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          service_account: ${{ secrets.CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT }}
+          allow_unauthenticated: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.terraform/
+terraform.tfstate*
+.idea/
+.vscode/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim AS base
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app/src
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+EXPOSE 8080
+
+CMD ["python", "-m", "http.server", "8080"]

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.85.0"
+  constraints = "~> 4.84"
+  hashes = [
+    "h1:aSRZcEKF2wOi/v24IA+k9J2Y7aKVV1cHi/R0V3EhxXQ=",
+    "zh:17d60a6a6c1741cf1e09ac6731433a30950285eac88236e623ab4cbf23832ca3",
+    "zh:1c70254c016439dbb75cab646b4beace6ceeff117c75d81f2cc27d41c312f752",
+    "zh:35e2aa2cc7ac84ce55e05bb4de7b461b169d3582e56d3262e249ff09d64fe008",
+    "zh:417afb08d7b2744429f6b76806f4134d62b0354acf98e8a6c00de3c24f2bb6ad",
+    "zh:622165d09d21d9a922c86f1fc7177a400507f2a8c4a4513114407ae04da2dd29",
+    "zh:7cdb8e39a8ea0939558d87d2cb6caceded9e21f21003d9e9f9ce648d5db0bc3a",
+    "zh:851e737dc551d6004a860a8907fda65118fc2c7ede9fa828f7be704a2a39e68f",
+    "zh:a331ad289a02a2c4473572a573dc389be0a604cdd9e03dd8dbc10297fb14f14d",
+    "zh:b67fd531251380decd8dd1f849460d60f329f89df3d15f5815849a1dd001f430",
+    "zh:be8785957acca4f97aa3e800b313b57d1fca07788761c8867c9bc701fbe0bdb5",
+    "zh:cb6579a259fe020e1f88217d8f6937b2d5ace15b6406370977a1966eb31b1ca5",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,31 @@
+# Terraform deployment
+
+This configuration provisions the core infrastructure required for the analytics lakehouse stack on Google Cloud Platform. It creates storage buckets for Apache Iceberg data and metadata, a log bucket for Stripe webhooks, service accounts with the minimum roles for each workload, and an Artifact Registry repository that stores container images used by Cloud Run services.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) 1.4 or newer
+- A Google Cloud project with billing enabled
+- The `gcloud` CLI authenticated against the target project (to supply application default credentials)
+
+## Usage
+
+```bash
+cd infra/terraform
+terraform init -backend=false
+terraform plan \
+  -var="project_id=<your-gcp-project>" \
+  -var="region=us-central1"
+```
+
+The `bucket_prefix` variable defaults to the project ID. Override it when you need globally unique bucket names across multiple environments/projects.
+
+Provision the resources once you are satisfied with the plan:
+
+```bash
+terraform apply \
+  -var="project_id=<your-gcp-project>" \
+  -var="region=us-central1"
+```
+
+Outputs include the fully qualified bucket names and service account emails. Use the `cloud_run_service_account_email` when deploying Cloud Run services so the workloads inherit access to Firestore and the Iceberg buckets.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,111 @@
+locals {
+  bucket_prefix = coalesce(var.bucket_prefix, var.project_id)
+  bucket_names = {
+    iceberg_data        = "${local.bucket_prefix}-iceberg-data"
+    iceberg_metadata    = "${local.bucket_prefix}-iceberg-metadata"
+    stripe_webhook_logs = "${local.bucket_prefix}-stripe-webhook-logs"
+  }
+  required_services = [
+    "artifactregistry.googleapis.com",
+    "run.googleapis.com",
+    "firestore.googleapis.com",
+    "iam.googleapis.com",
+    "cloudbuild.googleapis.com"
+  ]
+}
+
+resource "google_project_service" "services" {
+  for_each = toset(local.required_services)
+
+  service = each.value
+}
+
+resource "google_storage_bucket" "buckets" {
+  for_each = local.bucket_names
+
+  name                        = each.value
+  location                    = var.bucket_location
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  labels                      = var.labels
+
+  versioning {
+    enabled = true
+  }
+
+  dynamic "lifecycle_rule" {
+    for_each = each.key == "stripe_webhook_logs" ? [1] : []
+
+    content {
+      condition {
+        age = 30
+      }
+      action {
+        type = "Delete"
+      }
+    }
+  }
+}
+
+resource "google_service_account" "cloud_run" {
+  account_id   = "cloud-run-runtime"
+  display_name = "Cloud Run runtime service account"
+}
+
+resource "google_service_account" "firestore" {
+  account_id   = "firestore-app"
+  display_name = "Application Firestore service account"
+}
+
+resource "google_service_account" "stripe_webhook" {
+  account_id   = "stripe-webhook"
+  display_name = "Stripe webhook processor service account"
+}
+
+resource "google_project_iam_member" "cloud_run_roles" {
+  for_each = toset([
+    "roles/datastore.user",
+    "roles/storage.objectAdmin"
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_artifact_registry_repository" "containers" {
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  description   = "Container images for analytics services"
+  format        = "DOCKER"
+  labels        = var.labels
+
+  depends_on = [
+    google_project_service.services["artifactregistry.googleapis.com"]
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "cloud_run_reader" {
+  repository = google_artifact_registry_repository.containers.name
+  location   = google_artifact_registry_repository.containers.location
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "firestore_roles" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.firestore.email}"
+}
+
+resource "google_project_iam_member" "stripe_firestorereader" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.stripe_webhook.email}"
+}
+
+resource "google_storage_bucket_iam_member" "stripe_log_writer" {
+  bucket = google_storage_bucket.buckets["stripe_webhook_logs"].name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.stripe_webhook.email}"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "iceberg_data_bucket" {
+  description = "Bucket hosting Apache Iceberg table data."
+  value       = google_storage_bucket.buckets["iceberg_data"].name
+}
+
+output "iceberg_metadata_bucket" {
+  description = "Bucket storing Apache Iceberg table metadata."
+  value       = google_storage_bucket.buckets["iceberg_metadata"].name
+}
+
+output "stripe_webhook_logs_bucket" {
+  description = "Bucket capturing Stripe webhook request logs."
+  value       = google_storage_bucket.buckets["stripe_webhook_logs"].name
+}
+
+output "cloud_run_service_account_email" {
+  description = "Email for the Cloud Run runtime service account."
+  value       = google_service_account.cloud_run.email
+}
+
+output "firestore_service_account_email" {
+  description = "Email for the service account accessing Firestore."
+  value       = google_service_account.firestore.email
+}
+
+output "stripe_webhook_service_account_email" {
+  description = "Email for the Stripe webhook handler service account."
+  value       = google_service_account.stripe_webhook.email
+}
+
+output "artifact_registry_repository" {
+  description = "Artifact Registry repository URI."
+  value       = google_artifact_registry_repository.containers.id
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,37 @@
+variable "project_id" {
+  description = "GCP project ID where resources will be created."
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for regional resources such as Artifact Registry."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "bucket_location" {
+  description = "Location/region for GCS buckets."
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_prefix" {
+  description = "Prefix applied to storage buckets to guarantee uniqueness across environments. Defaults to the project ID."
+  type        = string
+  default     = null
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Name of the Artifact Registry repository used for container images."
+  type        = string
+  default     = "analytics-services"
+}
+
+variable "labels" {
+  description = "Common labels applied to all managed resources."
+  type        = map(string)
+  default = {
+    managed-by = "terraform"
+    project    = "lakehouse"
+  }
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.84"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-storage>=2.13.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Application source for the analytics lakehouse stack."""

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,11 @@
+"""Storage backends for the analytics lakehouse."""
+
+from .gcs import GCSObjectStore
+from .object_store import ObjectMetadata, ObjectStore, ObjectStoreError
+
+__all__ = [
+    "GCSObjectStore",
+    "ObjectMetadata",
+    "ObjectStore",
+    "ObjectStoreError",
+]

--- a/src/storage/gcs.py
+++ b/src/storage/gcs.py
@@ -1,0 +1,58 @@
+"""Google Cloud Storage implementation of the :mod:`storage.object_store` interface."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import storage
+
+from .object_store import ObjectMetadata, ObjectStore, ObjectStoreError
+
+
+class GCSObjectStore(ObjectStore):
+    """Interact with Google Cloud Storage using the common :class:`ObjectStore` API."""
+
+    def __init__(
+        self,
+        bucket_name: str,
+        *,
+        project: str | None = None,
+        client: storage.Client | None = None,
+    ) -> None:
+        self._bucket_name = bucket_name
+        self._project = project
+        self._client = client
+
+    @property
+    def _client_instance(self) -> storage.Client:
+        if self._client is None:
+            self._client = storage.Client(project=self._project)
+        return self._client
+
+    def _blob(self, path: str) -> storage.Blob:
+        return self._client_instance.bucket(self._bucket_name).blob(path)
+
+    def read(self, path: str) -> bytes:
+        try:
+            return self._blob(path).download_as_bytes()
+        except GoogleAPIError as exc:  # pragma: no cover - network failure path
+            raise ObjectStoreError(f"Failed to read object '{path}' from bucket '{self._bucket_name}'.", cause=exc) from exc
+
+    def write(self, path: str, data: bytes, *, content_type: str | None = None) -> None:
+        blob = self._blob(path)
+        try:
+            blob.upload_from_string(data, content_type=content_type)
+        except GoogleAPIError as exc:  # pragma: no cover - network failure path
+            raise ObjectStoreError(
+                f"Failed to write object '{path}' to bucket '{self._bucket_name}'.", cause=exc
+            ) from exc
+
+    def list(self, prefix: str = "") -> Iterable[ObjectMetadata]:
+        try:
+            for blob in self._client_instance.list_blobs(self._bucket_name, prefix=prefix):
+                yield ObjectMetadata(name=blob.name, size=blob.size or 0)
+        except GoogleAPIError as exc:  # pragma: no cover - network failure path
+            raise ObjectStoreError(
+                f"Failed to list objects under '{prefix}' in bucket '{self._bucket_name}'.", cause=exc
+            ) from exc

--- a/src/storage/object_store.py
+++ b/src/storage/object_store.py
@@ -1,0 +1,41 @@
+"""Common abstraction for object storage backends.
+
+The application relies on an object store for Apache Iceberg table data as well as
+auxiliary metadata such as Stripe webhook payloads. To support multiple
+clouds, we rely on a thin interface that captures the operations we need.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol, runtime_checkable
+
+
+@dataclass
+class ObjectMetadata:
+    """Metadata returned when listing objects."""
+
+    name: str
+    size: int
+
+
+@runtime_checkable
+class ObjectStore(Protocol):
+    """Interface implemented by cloud-specific object storage clients."""
+
+    def read(self, path: str) -> bytes:
+        """Return the raw contents stored at ``path``."""
+
+    def write(self, path: str, data: bytes, *, content_type: str | None = None) -> None:
+        """Persist ``data`` to ``path`` using an optional ``content_type``."""
+
+    def list(self, prefix: str = "") -> Iterable[ObjectMetadata]:
+        """Yield objects that start with ``prefix`` in lexicographic order."""
+
+
+class ObjectStoreError(RuntimeError):
+    """Raised when an object storage backend encounters an unrecoverable error."""
+
+    def __init__(self, message: str, *, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.__cause__ = cause


### PR DESCRIPTION
## Summary
- provision core GCP resources (buckets, service accounts, Artifact Registry) with Terraform and document usage
- add CI workflows for building images and deploying to staging/production Cloud Run targets
- scaffold a Docker image, Python object-store abstraction, and GCS implementation for future services

## Testing
- terraform fmt
- terraform init -backend=false
- terraform validate
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68c9d5440f1c833284a4af44081dc271