### PR TITLE
Add Iceberg catalog bootstrap utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,16 @@ limits within the API.
 - Cloud Run webhook handler syncing Firestore entitlements (`src/webhooks/stripe.py`).
 - API helpers enforcing daily query/data caps (`src/api/entitlements.py`).
 - Architecture overview in `/docs/architecture/billing-entitlements.md`.
+
+## Phase 4 — Iceberg Catalog & Data Lifecycle
+
+### Objective:
+Bootstrap per-client Iceberg catalogs and manage table schemas across clouds.
+
+### Deliverables:
+
+- Configurable catalog configuration abstraction (`src/iceberg/config.py`).
+- Storage bootstrapper that materialises warehouse prefixes (`src/iceberg/storage.py`).
+- Catalog bootstrap orchestrator and default table bundle (`src/iceberg/bootstrap.py`, `src/iceberg/tables.py`).
+- Schema evolution helper for safe column additions (`src/iceberg/schema.py`).
+- Architecture notes in `/docs/architecture/iceberg-catalog-bootstrap.md`.

--- a/docs/architecture/iceberg-catalog-bootstrap.md
+++ b/docs/architecture/iceberg-catalog-bootstrap.md
@@ -1,0 +1,67 @@
+# Iceberg Catalog Bootstrap & Data Lifecycle
+
+This phase introduces the per-client Iceberg catalog layout and the lifecycle primitives that keep table schemas in sync across providers.
+
+## Catalog layout
+
+Each tenant receives an isolated Iceberg namespace. The namespace is derived from a configurable prefix and the tenant identifier:
+
+```
+namespace = (<namespace_prefix...>, <client_id>)
+warehouse = <scheme>://<bucket>/<warehouse_prefix>/<namespace_path>
+```
+
+The configuration is expressed via [`IcebergCatalogConfig`](../../src/iceberg/config.py). It accepts the catalog name, the object store provider (GCS, S3, or Azure Blob), the warehouse bucket/prefix, and optional metadata bucket details. The helper normalises URIs and exposes convenience methods for building table locations.
+
+## Object store bootstrap
+
+The [`WarehouseStorageManager`](../../src/iceberg/storage.py) writes a `.catalog-bootstrap` marker beneath the warehouse (and optional metadata) prefixes. GCS does not materialise empty directories, so creating the marker ensures the prefix exists before the catalog service begins writing metadata. The manager delegates to a pluggable `ObjectStore` factory. The default implementation supports Google Cloud Storage, while the interface is generic enough to register S3 or Azure Blob providers.
+
+## Namespace and table provisioning
+
+[`IcebergCatalogBootstrapper`](../../src/iceberg/bootstrap.py) orchestrates the full bootstrap flow:
+
+1. Pre-create object store prefixes through the storage manager.
+2. Connect to the configured Iceberg catalog using `pyiceberg`.
+3. Create the per-client namespace, setting the `location` property to the warehouse URI.
+4. Materialise default tables when they are missing. The initial bundle includes `main`, `events`, and `metrics`, as described in [`tables.py`](../../src/iceberg/tables.py). Each table definition captures schema, partitioning, and write properties.
+
+The class returns a `CatalogBootstrapResult` object that lists the namespace, warehouse URI, created tables, and the bootstrap markers. Bootstrapping is idempotent—rerunning the workflow simply leaves existing namespaces and tables untouched.
+
+## Schema evolution
+
+[`SchemaEvolutionManager`](../../src/iceberg/schema.py) encapsulates our schema change strategy. The helper loads a table, compares the desired columns with the current schema, and adds any missing optional columns using Iceberg's schema update API. Required columns are rejected to avoid backfills that would violate Iceberg's compatibility guarantees. The manager refreshes the table metadata after committing changes so downstream readers observe the new schema immediately.
+
+## Resolving client catalogs
+
+Consumers resolve catalog handles through the same configuration object and bootstrapper:
+
+```python
+from iceberg import (
+    CatalogProvider,
+    IcebergCatalogBootstrapper,
+    IcebergCatalogConfig,
+)
+
+config = IcebergCatalogConfig(
+    name="clients",
+    provider=CatalogProvider.GCS,
+    warehouse_bucket="my-data-bucket",
+    warehouse_prefix="warehouse",
+)
+bootstrapper = IcebergCatalogBootstrapper()
+result = bootstrapper.bootstrap_client("tenant-123", config)
+
+handle = bootstrapper.open_catalog("tenant-123", config)
+table = handle.catalog.load_table((*handle.namespace, "events"))
+```
+
+The `_load_pyiceberg_catalog` helper reuses `pyiceberg.catalog.load_catalog` and can be swapped out in tests by passing a custom loader to the bootstrapper.
+
+## Extensibility
+
+* **Providers** – new `CatalogProvider` enum values can be added as backends come online. Register a custom storage factory that returns the appropriate `ObjectStore` implementation for S3 or Azure.
+* **Tables** – supply custom `IcebergTableSpec` objects to `bootstrap_client` to provision additional tables.
+* **Schema management** – extend `SchemaEvolutionManager` with transformations such as rename or reorder while keeping the safety checks centralised.
+
+These building blocks establish a consistent tenant bootstrap process and a clear entry point for managing Iceberg table lifecycles across clouds.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-storage>=2.13.0
 google-cloud-firestore>=2.13.0
 stripe>=6.0.0
 flask>=2.3.0
+pytest>=7.4

--- a/src/iceberg/__init__.py
+++ b/src/iceberg/__init__.py
@@ -1,0 +1,24 @@
+"""Utilities for working with Apache Iceberg catalogs."""
+
+from .bootstrap import CatalogBootstrapResult, ClientCatalogHandle, IcebergCatalogBootstrapper
+from .config import CatalogProvider, IcebergCatalogConfig
+from .schema import SchemaEvolutionManager, SchemaEvolutionError
+from .storage import CatalogPrefixMarker, CatalogStorageError, DefaultCatalogStorageFactory, WarehouseStorageManager
+from .tables import DEFAULT_TABLES, IcebergTableSpec, SchemaField
+
+__all__ = [
+    "CatalogBootstrapResult",
+    "ClientCatalogHandle",
+    "CatalogPrefixMarker",
+    "CatalogProvider",
+    "CatalogStorageError",
+    "DEFAULT_TABLES",
+    "IcebergCatalogBootstrapper",
+    "IcebergCatalogConfig",
+    "IcebergTableSpec",
+    "SchemaEvolutionError",
+    "SchemaEvolutionManager",
+    "SchemaField",
+    "WarehouseStorageManager",
+    "DefaultCatalogStorageFactory",
+]

--- a/src/iceberg/bootstrap.py
+++ b/src/iceberg/bootstrap.py
@@ -1,0 +1,165 @@
+"""Bootstrap helpers for per-client Iceberg catalogs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence, Tuple, TYPE_CHECKING
+
+from .config import IcebergCatalogConfig
+from .storage import CatalogPrefixMarker, WarehouseStorageManager
+from .tables import DEFAULT_TABLES, IcebergTableSpec
+
+if TYPE_CHECKING:  # pragma: no cover - import only for typing
+    from pyiceberg.catalog import Catalog
+
+
+class CatalogBootstrapError(RuntimeError):
+    """Raised when a catalog bootstrap operation fails."""
+
+
+@dataclass(frozen=True)
+class CatalogBootstrapResult:
+    """Summary of the actions performed while bootstrapping a catalog."""
+
+    client_id: str
+    namespace: Tuple[str, ...]
+    warehouse_uri: str
+    created_namespace: bool
+    created_tables: Tuple[Tuple[str, ...], ...]
+    prefix_markers: Tuple[CatalogPrefixMarker, ...]
+
+
+@dataclass(frozen=True)
+class ClientCatalogHandle:
+    """Return value for :meth:`IcebergCatalogBootstrapper.open_catalog`."""
+
+    client_id: str
+    catalog: "Catalog"
+    namespace: Tuple[str, ...]
+    warehouse_uri: str
+
+
+class IcebergCatalogBootstrapper:
+    """Create namespaces and tables for a client's Iceberg catalog."""
+
+    def __init__(
+        self,
+        storage_manager: WarehouseStorageManager | None = None,
+        *,
+        load_catalog: Callable[..., "Catalog"] | None = None,
+    ) -> None:
+        self._storage_manager = storage_manager or WarehouseStorageManager()
+        self._load_catalog = load_catalog
+
+    def _load_pyiceberg_catalog(self, config: IcebergCatalogConfig) -> "Catalog":
+        if self._load_catalog is not None:
+            return self._load_catalog(config.catalog_name, **config.catalog_options)
+
+        try:
+            from pyiceberg.catalog import load_catalog  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise CatalogBootstrapError(
+                "The 'pyiceberg' package is required to bootstrap Iceberg catalogs. Install it via 'pip install pyiceberg'."
+            ) from exc
+
+        return load_catalog(config.catalog_name, **config.catalog_options)
+
+    def open_catalog(self, client_id: str, config: IcebergCatalogConfig) -> ClientCatalogHandle:
+        """Resolve the catalog handle, namespace, and warehouse for ``client_id``."""
+
+        if not client_id.strip():
+            raise ValueError("client_id must be a non-empty string")
+        catalog = self._load_pyiceberg_catalog(config)
+        namespace = config.namespace(client_id)
+        return ClientCatalogHandle(
+            client_id=client_id,
+            catalog=catalog,
+            namespace=namespace,
+            warehouse_uri=config.warehouse_uri(client_id),
+        )
+
+    def bootstrap_client(
+        self,
+        client_id: str,
+        config: IcebergCatalogConfig,
+        *,
+        tables: Sequence[IcebergTableSpec] | None = None,
+        extra_namespace_properties: Mapping[str, str] | None = None,
+    ) -> CatalogBootstrapResult:
+        """Ensure the namespace and default tables exist for ``client_id``."""
+
+        if not client_id.strip():
+            raise ValueError("client_id must be a non-empty string")
+
+        # Ensure object store prefixes exist ahead of namespace/table creation.
+        prefix_markers = self._prepare_storage(config, client_id)
+
+        catalog = self._load_pyiceberg_catalog(config)
+        namespace = config.namespace(client_id)
+
+        namespace_properties = {"location": config.warehouse_uri(client_id)}
+        namespace_properties.update(config.namespace_properties)
+        if extra_namespace_properties:
+            namespace_properties.update(extra_namespace_properties)
+
+        created_namespace = False
+        if not catalog.namespace_exists(namespace):
+            catalog.create_namespace(namespace, namespace_properties)
+            created_namespace = True
+
+        tables_to_create: Sequence[IcebergTableSpec] = tables or DEFAULT_TABLES
+        created_tables: list[Tuple[str, ...]] = []
+        for table in tables_to_create:
+            identifier = table.identifier(namespace)
+            if catalog.table_exists(identifier):
+                continue
+            schema = table.to_pyiceberg_schema()
+            partition_spec = table.to_pyiceberg_partition_spec(schema)
+            location = table.location(config, client_id)
+            create_kwargs: dict[str, object] = {
+                "schema": schema,
+                "location": location,
+            }
+            if partition_spec is not None and getattr(partition_spec, "fields", None):
+                create_kwargs["partition_spec"] = partition_spec
+            if table.properties:
+                create_kwargs["properties"] = dict(table.properties)
+            catalog.create_table(identifier, **create_kwargs)
+            created_tables.append(identifier)
+
+        return CatalogBootstrapResult(
+            client_id=client_id,
+            namespace=namespace,
+            warehouse_uri=config.warehouse_uri(client_id),
+            created_namespace=created_namespace,
+            created_tables=tuple(created_tables),
+            prefix_markers=tuple(prefix_markers),
+        )
+
+    def _prepare_storage(
+        self,
+        config: IcebergCatalogConfig,
+        client_id: str,
+    ) -> Tuple[CatalogPrefixMarker, ...]:
+        markers: list[CatalogPrefixMarker] = []
+        warehouse_prefix = config.warehouse_path(client_id)
+        marker = self._storage_manager.ensure_prefix(
+            config.provider,
+            bucket=config.warehouse_bucket,
+            prefix=warehouse_prefix,
+            provider_options=config.provider_options,
+        )
+        if marker is not None:
+            markers.append(marker)
+
+        metadata_prefix = config.metadata_path(client_id)
+        if config.metadata_bucket and metadata_prefix:
+            metadata_marker = self._storage_manager.ensure_prefix(
+                config.provider,
+                bucket=config.metadata_bucket,
+                prefix=metadata_prefix,
+                provider_options=config.provider_options,
+            )
+            if metadata_marker is not None:
+                markers.append(metadata_marker)
+        return tuple(markers)

--- a/src/iceberg/config.py
+++ b/src/iceberg/config.py
@@ -1,0 +1,124 @@
+"""Configuration helpers for Iceberg catalog bootstrapping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, Tuple
+
+
+class CatalogProvider(str, Enum):
+    """Supported object storage providers for Iceberg warehouses."""
+
+    GCS = "gcs"
+    S3 = "s3"
+    AZURE_BLOB = "azure"
+
+    @property
+    def scheme(self) -> str:
+        """Return the URI scheme associated with the provider."""
+
+        match self:
+            case CatalogProvider.GCS:
+                return "gs"
+            case CatalogProvider.S3:
+                return "s3"
+            case CatalogProvider.AZURE_BLOB:
+                # Azure Data Lake Storage Gen2 (`abfs`) is the most common URI format.
+                return "abfs"
+        raise ValueError(f"Unsupported catalog provider: {self!s}")
+
+
+@dataclass(frozen=True)
+class IcebergCatalogConfig:
+    """Describe how to resolve catalog, namespace, and warehouse locations."""
+
+    name: str
+    provider: CatalogProvider
+    warehouse_bucket: str
+    warehouse_prefix: str = ""
+    namespace_prefix: Tuple[str, ...] = ("clients",)
+    catalog_options: Mapping[str, Any] = field(default_factory=dict)
+    namespace_properties: Mapping[str, str] = field(default_factory=dict)
+    provider_options: Mapping[str, Any] = field(default_factory=dict)
+    metadata_bucket: str | None = None
+    metadata_prefix: str | None = None
+
+    def namespace(self, client_id: str) -> Tuple[str, ...]:
+        """Return the Iceberg namespace tuple for ``client_id``."""
+
+        client_segment = client_id.strip()
+        if not client_segment:
+            raise ValueError("client_id must be a non-empty string")
+        return (*self.namespace_prefix, client_segment)
+
+    def namespace_path(self, client_id: str) -> str:
+        """Return the namespace path used within the warehouse location."""
+
+        return "/".join(self.namespace(client_id))
+
+    def _join_path(self, *segments: Iterable[str | None]) -> str:
+        parts: list[str] = []
+        for segment in segments:
+            if segment is None:
+                continue
+            if isinstance(segment, str):
+                normalized = segment.strip("/")
+                if normalized:
+                    parts.append(normalized)
+                continue
+            for value in segment:
+                if value is None:
+                    continue
+                normalized = value.strip("/")
+                if normalized:
+                    parts.append(normalized)
+        return "/".join(parts)
+
+    def warehouse_path(self, client_id: str) -> str:
+        """Return the object store prefix for the client's warehouse."""
+
+        return self._join_path([self.warehouse_prefix], [self.namespace_path(client_id)])
+
+    def warehouse_uri(self, client_id: str) -> str:
+        """Return the fully qualified URI for the client's warehouse."""
+
+        path = self.warehouse_path(client_id)
+        scheme = self.provider.scheme
+        bucket = self.warehouse_bucket.strip()
+        if path:
+            return f"{scheme}://{bucket}/{path}"
+        return f"{scheme}://{bucket}"
+
+    def metadata_path(self, client_id: str) -> str | None:
+        """Return the metadata prefix if a dedicated metadata bucket is configured."""
+
+        if not self.metadata_bucket:
+            return None
+        prefix = self.metadata_prefix if self.metadata_prefix is not None else self.warehouse_prefix
+        return self._join_path([prefix], [self.namespace_path(client_id)])
+
+    def metadata_uri(self, client_id: str) -> str | None:
+        """Return the URI for metadata objects when configured."""
+
+        if not self.metadata_bucket:
+            return None
+        path = self.metadata_path(client_id)
+        scheme = self.provider.scheme
+        bucket = self.metadata_bucket.strip()
+        if path:
+            return f"{scheme}://{bucket}/{path}"
+        return f"{scheme}://{bucket}"
+
+    def table_location(self, client_id: str, table_name: str) -> str:
+        """Compute the default table location within the client's warehouse."""
+
+        base = self.warehouse_uri(client_id).rstrip("/")
+        return f"{base}/{table_name.strip()}"
+
+    @property
+    def catalog_name(self) -> str:
+        """Expose the catalog name used by :func:`pyiceberg.catalog.load_catalog`."""
+
+        return self.name
+

--- a/src/iceberg/schema.py
+++ b/src/iceberg/schema.py
@@ -1,0 +1,65 @@
+"""Schema management utilities for Iceberg tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple, TYPE_CHECKING
+
+from .tables import SchemaField
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyiceberg.catalog import Catalog
+    from pyiceberg.table import Table
+
+
+class SchemaEvolutionError(RuntimeError):
+    """Raised when schema evolution cannot be completed safely."""
+
+
+@dataclass
+class SchemaEvolutionManager:
+    """Orchestrate safe schema changes for Iceberg tables."""
+
+    catalog: "Catalog"
+    table_identifier: Tuple[str, ...]
+
+    def add_columns_if_missing(self, columns: Sequence[SchemaField]) -> Tuple[str, ...]:
+        """Add non-breaking columns to the table schema."""
+
+        if not columns:
+            return tuple()
+
+        table = self._load_table()
+        schema = table.schema()
+        update = table.update_schema()
+
+        added: list[str] = []
+        for column in columns:
+            if column.required:
+                raise SchemaEvolutionError(
+                    f"Refusing to add required column '{column.dotted_path()}'. Iceberg can only add optional columns safely."
+                )
+            if schema.find_field(column.dotted_path()) is not None:
+                continue
+            parent = column.parent if column.parent else ()
+            try:
+                iceberg_type = column.to_iceberg_type()
+            except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+                raise SchemaEvolutionError(
+                    "The 'pyiceberg' package is required to evolve table schemas. Install it via 'pip install pyiceberg'."
+                ) from exc
+            update.add_column(parent, column.name, iceberg_type, doc=column.doc)
+            added.append(column.dotted_path())
+
+        if added:
+            update.commit()
+            table.refresh()
+        return tuple(added)
+
+    def _load_table(self) -> "Table":
+        try:
+            return self.catalog.load_table(self.table_identifier)
+        except Exception as exc:  # pragma: no cover - propagate informative error
+            raise SchemaEvolutionError(
+                f"Unable to load table '{'.'.join(self.table_identifier)}' for schema evolution."
+            ) from exc

--- a/src/iceberg/storage.py
+++ b/src/iceberg/storage.py
@@ -1,0 +1,79 @@
+"""Helpers for preparing object storage prefixes used by Iceberg catalogs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping
+
+from .config import CatalogProvider
+from storage.object_store import ObjectStore, ObjectStoreError
+
+
+class CatalogStorageError(RuntimeError):
+    """Raised when bootstrapping object store prefixes fails."""
+
+
+@dataclass(frozen=True)
+class CatalogPrefixMarker:
+    """Record of an object created to assert a catalog prefix exists."""
+
+    provider: CatalogProvider
+    bucket: str
+    path: str
+
+
+StorageFactory = Callable[[CatalogProvider, str, Mapping[str, Any]], ObjectStore]
+
+
+class DefaultCatalogStorageFactory:
+    """Instantiate :class:`ObjectStore` implementations for supported providers."""
+
+    def __call__(self, provider: CatalogProvider, bucket: str, options: Mapping[str, Any]) -> ObjectStore:
+        if provider is CatalogProvider.GCS:
+            from storage.gcs import GCSObjectStore
+
+            project = options.get("project") if options else None
+            client = options.get("client") if options else None
+            return GCSObjectStore(bucket, project=project, client=client)
+        raise CatalogStorageError(
+            f"Provider '{provider.value}' is not supported by the default catalog storage factory."
+        )
+
+
+class WarehouseStorageManager:
+    """Ensure warehouse prefixes exist prior to catalog bootstrap."""
+
+    def __init__(
+        self,
+        storage_factory: StorageFactory | None = None,
+        marker_filename: str = ".catalog-bootstrap",
+    ) -> None:
+        self._storage_factory = storage_factory or DefaultCatalogStorageFactory()
+        self._marker_filename = marker_filename
+
+    def ensure_prefix(
+        self,
+        provider: CatalogProvider,
+        *,
+        bucket: str,
+        prefix: str,
+        provider_options: Mapping[str, Any] | None = None,
+    ) -> CatalogPrefixMarker | None:
+        """Create a placeholder object so the prefix is visible in the provider console."""
+
+        normalized_prefix = prefix.strip("/")
+        if not normalized_prefix:
+            return None
+
+        store = self._storage_factory(provider, bucket, provider_options or {})
+        marker_path = f"{normalized_prefix}/{self._marker_filename}" if normalized_prefix else self._marker_filename
+        timestamp = datetime.now(timezone.utc).isoformat()
+        payload = f"Bootstrap marker written at {timestamp} UTC".encode("utf-8")
+        try:
+            store.write(marker_path, payload, content_type="text/plain")
+        except Exception as exc:
+            raise CatalogStorageError(
+                f"Unable to write bootstrap marker to {provider.value} bucket '{bucket}' under '{marker_path}'."
+            ) from exc
+        return CatalogPrefixMarker(provider=provider, bucket=bucket, path=marker_path)

--- a/src/iceberg/tables.py
+++ b/src/iceberg/tables.py
@@ -1,0 +1,210 @@
+"""Declarative table specifications for Iceberg catalog bootstrapping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence, Tuple, TYPE_CHECKING
+
+from .config import IcebergCatalogConfig
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from pyiceberg.partitioning import PartitionSpec
+    from pyiceberg.schema import Schema
+
+
+@dataclass(frozen=True)
+class SchemaField:
+    """Describe a column in an Iceberg table schema."""
+
+    name: str
+    type: str
+    required: bool = False
+    doc: str | None = None
+    parent: Tuple[str, ...] = ()
+
+    @property
+    def path(self) -> Tuple[str, ...]:
+        return (*self.parent, self.name)
+
+    def to_iceberg_type(self):
+        """Return the :mod:`pyiceberg` type object for this field."""
+
+        try:
+            from pyiceberg.types import (  # type: ignore
+                BinaryType,
+                BooleanType,
+                DateType,
+                DecimalType,
+                DoubleType,
+                FloatType,
+                IntegerType,
+                LongType,
+                StringType,
+                TimestampType,
+                UUIDType,
+            )
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "The 'pyiceberg' package is required to materialize Iceberg schemas. Install it via 'pip install pyiceberg'."
+            ) from exc
+
+        normalized = self.type.strip().lower()
+        if normalized.startswith("decimal"):
+            precision, scale = _parse_decimal(normalized)
+            return DecimalType(precision, scale)
+        match normalized:
+            case "string":
+                return StringType()
+            case "boolean":
+                return BooleanType()
+            case "binary":
+                return BinaryType()
+            case "int" | "integer":
+                return IntegerType()
+            case "long":
+                return LongType()
+            case "float":
+                return FloatType()
+            case "double":
+                return DoubleType()
+            case "date":
+                return DateType()
+            case "timestamp":
+                return TimestampType(False)
+            case "timestamptz" | "timestamp_tz" | "timestamp with time zone":
+                return TimestampType(True)
+            case "uuid":
+                return UUIDType()
+        raise ValueError(f"Unsupported Iceberg field type: {self.type!s}")
+
+    def to_nested_field(self, field_id: int):
+        """Convert the column definition to a :class:`pyiceberg.schema.NestedField`."""
+
+        try:
+            from pyiceberg.schema import NestedField  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "The 'pyiceberg' package is required to materialize Iceberg schemas. Install it via 'pip install pyiceberg'."
+            ) from exc
+
+        return NestedField(field_id, self.name, self.to_iceberg_type(), required=self.required, doc=self.doc)
+
+    def dotted_path(self) -> str:
+        return ".".join(self.path)
+
+
+@dataclass(frozen=True)
+class IcebergTableSpec:
+    """Represent the desired layout of an Iceberg table."""
+
+    name: str
+    fields: Sequence[SchemaField]
+    partition_by: Sequence[str] = field(default_factory=tuple)
+    properties: Mapping[str, str] = field(default_factory=dict)
+
+    def identifier(self, namespace: Tuple[str, ...]) -> Tuple[str, ...]:
+        return (*namespace, self.name)
+
+    def to_pyiceberg_schema(self) -> "Schema":
+        try:
+            from pyiceberg.schema import Schema  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "The 'pyiceberg' package is required to materialize Iceberg schemas. Install it via 'pip install pyiceberg'."
+            ) from exc
+
+        fields = [field.to_nested_field(idx) for idx, field in enumerate(self.fields, start=1)]
+        return Schema(*fields)
+
+    def to_pyiceberg_partition_spec(self, schema: "Schema") -> "PartitionSpec | None":
+        if not self.partition_by:
+            return None
+        try:
+            from pyiceberg.partitioning import PartitionField, PartitionSpec  # type: ignore
+            from pyiceberg.transforms import IdentityTransform  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "The 'pyiceberg' package is required to materialize Iceberg schemas. Install it via 'pip install pyiceberg'."
+            ) from exc
+
+        fields: list[PartitionField] = []
+        next_field_id = schema.highest_field_id + 1
+        for offset, column in enumerate(self.partition_by):
+            target = schema.find_field(column)
+            if target is None:
+                raise ValueError(f"Partition column '{column}' is not present in the schema for table '{self.name}'.")
+            fields.append(
+                PartitionField(
+                    source_id=target.field_id,
+                    field_id=next_field_id + offset,
+                    transform=IdentityTransform(),
+                    name=column,
+                )
+            )
+        return PartitionSpec(*fields)
+
+    def location(self, config: IcebergCatalogConfig, client_id: str) -> str:
+        return config.table_location(client_id, self.name)
+
+
+DEFAULT_TABLES: Tuple[IcebergTableSpec, ...] = (
+    IcebergTableSpec(
+        name="main",
+        fields=(
+            SchemaField("record_id", "string", required=True, doc="Stable identifier for the record."),
+            SchemaField("source", "string", doc="System that produced the record."),
+            SchemaField("payload", "string", doc="Raw JSON payload ingested from the source system."),
+            SchemaField("ingested_at", "timestamptz", doc="Timestamp when the record reached the warehouse."),
+            SchemaField("ingested_date", "date", doc="Calendar date derived from ingested_at for filtering."),
+        ),
+        partition_by=("ingested_date",),
+        properties={
+            "write.format.default": "parquet",
+            "write.target-file-size-bytes": str(512 * 1024 * 1024),
+        },
+    ),
+    IcebergTableSpec(
+        name="events",
+        fields=(
+            SchemaField("event_id", "string", required=True, doc="Unique identifier for the event."),
+            SchemaField("event_type", "string", doc="Logical type or category for the event."),
+            SchemaField("occurred_at", "timestamptz", doc="When the event took place according to the producer."),
+            SchemaField("ingested_at", "timestamptz", doc="Ingestion timestamp assigned by the pipeline."),
+            SchemaField("properties", "string", doc="Semi-structured JSON payload for event attributes."),
+        ),
+        partition_by=("occurred_at",),
+        properties={
+            "write.format.default": "parquet",
+        },
+    ),
+    IcebergTableSpec(
+        name="metrics",
+        fields=(
+            SchemaField("metric_id", "string", required=True, doc="Identifier for the metric sample."),
+            SchemaField("metric_name", "string", doc="Human-friendly metric name."),
+            SchemaField("metric_value", "double", doc="Numeric value captured for the metric."),
+            SchemaField("captured_at", "timestamptz", doc="Time when the metric was captured."),
+            SchemaField("dimensions", "string", doc="JSON object describing metric dimensions or tags."),
+        ),
+        partition_by=("captured_at",),
+        properties={
+            "write.format.default": "parquet",
+        },
+    ),
+)
+
+
+def _parse_decimal(spec: str) -> Tuple[int, int]:
+    start = spec.find("(")
+    end = spec.find(")")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError(f"Decimal specification '{spec}' must look like decimal(precision,scale)")
+    precision_scale = spec[start + 1 : end]
+    precision_str, _, scale_str = precision_scale.partition(",")
+    try:
+        precision = int(precision_str.strip())
+        scale = int(scale_str.strip())
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"Invalid decimal precision/scale in '{spec}'.") from exc
+    return precision, scale
+

--- a/tests/test_iceberg_bootstrapper.py
+++ b/tests/test_iceberg_bootstrapper.py
@@ -1,0 +1,81 @@
+from iceberg.bootstrap import IcebergCatalogBootstrapper, ClientCatalogHandle
+from iceberg.config import CatalogProvider, IcebergCatalogConfig
+from iceberg.storage import CatalogPrefixMarker
+
+
+class FakeCatalog:
+    def __init__(self) -> None:
+        self.namespaces: set[tuple[str, ...]] = set()
+
+    def namespace_exists(self, namespace: tuple[str, ...]) -> bool:
+        return namespace in self.namespaces
+
+    def create_namespace(self, namespace: tuple[str, ...], properties: dict[str, str]):
+        self.namespaces.add(namespace)
+
+    def table_exists(self, identifier: tuple[str, ...]) -> bool:  # pragma: no cover - unused stub
+        return False
+
+    def create_table(self, identifier: tuple[str, ...], **kwargs):  # pragma: no cover - unused stub
+        raise AssertionError("create_table should not be called in this test")
+
+    def load_table(self, identifier: tuple[str, ...]):  # pragma: no cover - unused stub
+        raise NotImplementedError
+
+
+class RecordingStorageManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.markers: list[CatalogPrefixMarker] = []
+
+    def ensure_prefix(self, provider, *, bucket: str, prefix: str, provider_options):
+        self.calls.append((bucket, prefix))
+        marker = CatalogPrefixMarker(provider=provider, bucket=bucket, path=f"{prefix}/.catalog-bootstrap")
+        self.markers.append(marker)
+        return marker
+
+
+def test_open_catalog_uses_injected_loader():
+    catalog = FakeCatalog()
+
+    def loader(name: str, **options):
+        assert name == "clients"
+        assert options == {"uri": "https://catalog"}
+        return catalog
+
+    config = IcebergCatalogConfig(
+        name="clients",
+        provider=CatalogProvider.GCS,
+        warehouse_bucket="analytics",
+        catalog_options={"uri": "https://catalog"},
+    )
+
+    bootstrapper = IcebergCatalogBootstrapper(load_catalog=loader)
+    handle = bootstrapper.open_catalog("tenant-42", config)
+
+    assert isinstance(handle, ClientCatalogHandle)
+    assert handle.catalog is catalog
+    assert handle.namespace == ("clients", "tenant-42")
+    assert handle.warehouse_uri.endswith("tenant-42")
+
+
+def test_prepare_storage_creates_markers():
+    storage_manager = RecordingStorageManager()
+    bootstrapper = IcebergCatalogBootstrapper(storage_manager=storage_manager, load_catalog=lambda *a, **k: FakeCatalog())
+
+    config = IcebergCatalogConfig(
+        name="clients",
+        provider=CatalogProvider.GCS,
+        warehouse_bucket="analytics",
+        warehouse_prefix="warehouse",
+        metadata_bucket="metadata",
+        metadata_prefix="meta",
+    )
+
+    markers = bootstrapper._prepare_storage(config, "tenant-1")
+    assert len(markers) == 2
+    assert {marker.bucket for marker in markers} == {"analytics", "metadata"}
+    assert storage_manager.calls == [
+        ("analytics", "warehouse/clients/tenant-1"),
+        ("metadata", "meta/clients/tenant-1"),
+    ]

--- a/tests/test_iceberg_config.py
+++ b/tests/test_iceberg_config.py
@@ -1,0 +1,50 @@
+from iceberg.config import CatalogProvider, IcebergCatalogConfig
+
+
+def test_namespace_and_paths():
+    config = IcebergCatalogConfig(
+        name="clients",
+        provider=CatalogProvider.GCS,
+        warehouse_bucket="analytics-bucket",
+        warehouse_prefix="warehouse",
+        namespace_prefix=("tenants",),
+        metadata_bucket="metadata-bucket",
+        metadata_prefix="metadata",
+    )
+
+    namespace = config.namespace("client-123")
+    assert namespace == ("tenants", "client-123")
+
+    warehouse_path = config.warehouse_path("client-123")
+    assert warehouse_path == "warehouse/tenants/client-123"
+    assert (
+        config.warehouse_uri("client-123")
+        == "gs://analytics-bucket/warehouse/tenants/client-123"
+    )
+
+    metadata_path = config.metadata_path("client-123")
+    assert metadata_path == "metadata/tenants/client-123"
+    assert (
+        config.metadata_uri("client-123")
+        == "gs://metadata-bucket/metadata/tenants/client-123"
+    )
+
+    assert (
+        config.table_location("client-123", "events")
+        == "gs://analytics-bucket/warehouse/tenants/client-123/events"
+    )
+
+
+def test_namespace_rejects_blank_client_id():
+    config = IcebergCatalogConfig(
+        name="clients",
+        provider=CatalogProvider.S3,
+        warehouse_bucket="lakehouse",
+    )
+
+    try:
+        config.namespace(" ")
+    except ValueError as exc:
+        assert "client_id" in str(exc)
+    else:  # pragma: no cover - defensive guard
+        raise AssertionError("Blank client identifier should raise ValueError")

--- a/tests/test_iceberg_storage.py
+++ b/tests/test_iceberg_storage.py
@@ -1,0 +1,90 @@
+from iceberg.config import CatalogProvider
+from iceberg.storage import (
+    CatalogPrefixMarker,
+    CatalogStorageError,
+    WarehouseStorageManager,
+)
+from storage.object_store import ObjectStore
+
+
+class RecordingStore(ObjectStore):
+    def __init__(self) -> None:
+        self.writes: dict[str, tuple[bytes, str | None]] = {}
+
+    def read(self, path: str) -> bytes:  # pragma: no cover - not used in tests
+        raise NotImplementedError
+
+    def write(self, path: str, data: bytes, *, content_type: str | None = None) -> None:
+        self.writes[path] = (data, content_type)
+
+    def list(self, prefix: str = ""):
+        return []
+
+
+class BrokenStore(RecordingStore):
+    def write(self, path: str, data: bytes, *, content_type: str | None = None) -> None:
+        raise RuntimeError("boom")
+
+
+class RecordingFactory:
+    def __init__(self, store: ObjectStore) -> None:
+        self.store = store
+        self.calls: list[tuple[CatalogProvider, str, dict[str, object]]] = []
+
+    def __call__(self, provider: CatalogProvider, bucket: str, options: dict[str, object]):
+        self.calls.append((provider, bucket, options))
+        return self.store
+
+
+def test_storage_manager_writes_marker():
+    store = RecordingStore()
+    factory = RecordingFactory(store)
+    manager = WarehouseStorageManager(storage_factory=factory)
+
+    marker = manager.ensure_prefix(
+        CatalogProvider.GCS,
+        bucket="analytics-bucket",
+        prefix="warehouse/tenant-1",
+        provider_options={"project": "demo"},
+    )
+
+    assert isinstance(marker, CatalogPrefixMarker)
+    assert marker.path.startswith("warehouse/tenant-1/")
+    assert marker.bucket == "analytics-bucket"
+    assert CatalogProvider.GCS in {call[0] for call in factory.calls}
+    assert any(call[1] == "analytics-bucket" for call in factory.calls)
+    assert "warehouse/tenant-1/.catalog-bootstrap" in store.writes
+
+
+def test_storage_manager_returns_none_for_root_prefix():
+    store = RecordingStore()
+    factory = RecordingFactory(store)
+    manager = WarehouseStorageManager(storage_factory=factory)
+
+    marker = manager.ensure_prefix(
+        CatalogProvider.GCS,
+        bucket="analytics-bucket",
+        prefix="",
+        provider_options={},
+    )
+
+    assert marker is None
+    assert not store.writes
+
+
+def test_storage_manager_wraps_errors():
+    store = BrokenStore()
+    factory = RecordingFactory(store)
+    manager = WarehouseStorageManager(storage_factory=factory)
+
+    try:
+        manager.ensure_prefix(
+            CatalogProvider.GCS,
+            bucket="analytics-bucket",
+            prefix="warehouse/tenant-1",
+            provider_options={},
+        )
+    except CatalogStorageError as exc:
+        assert "analytics-bucket" in str(exc)
+    else:  # pragma: no cover - defensive guard
+        raise AssertionError("Expected CatalogStorageError")


### PR DESCRIPTION
## Summary
- add Iceberg catalog configuration, storage, bootstrap, and schema helpers for per-client catalogs
- document the catalog lifecycle and extend the roadmap with the new phase
- add unit tests for the new helpers and configure pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9ddeef6988332a7cc74b435bbed5a