### PR TITLE
feat: build marketing home page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,69 +1,24 @@
-import type { ReactElement } from "react";
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { lazy, Suspense } from "react";
+import { Route, Routes } from "react-router-dom";
 
 import { LoadingScreen } from "./components/LoadingScreen";
-import { AuthProvider, useAuth } from "./context/AuthContext";
-import { ClientProvider } from "./context/ClientContext";
-import { AppLayout } from "./layouts/AppLayout";
-import { BillingReturnPage } from "./pages/BillingReturnPage";
-import { DashboardPage } from "./pages/DashboardPage";
-import { LoginPage } from "./pages/LoginPage";
+import { HomePage } from "./pages/HomePage";
 
-function ProtectedRoute({ children }: { children: ReactElement }): JSX.Element {
-  const { user, loading } = useAuth();
-  const location = useLocation();
-
-  if (loading) {
-    return <LoadingScreen message="Checking authentication…" />;
-  }
-
-  if (!user) {
-    return <Navigate to="/login" replace state={{ from: location }} />;
-  }
-
-  return children;
-}
+const AuthenticatedApp = lazy(() => import("./AuthenticatedApp"));
 
 export function App(): JSX.Element {
   return (
-    <AuthProvider>
-      <ClientProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route
-            path="/billing/success"
-            element={
-              <ProtectedRoute>
-                <AppLayout>
-                  <BillingReturnPage status="success" />
-                </AppLayout>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/billing/cancel"
-            element={
-              <ProtectedRoute>
-                <AppLayout>
-                  <BillingReturnPage status="cancel" />
-                </AppLayout>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/"
-            element={
-              <ProtectedRoute>
-                <AppLayout>
-                  <DashboardPage />
-                </AppLayout>
-              </ProtectedRoute>
-            }
-          />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </ClientProvider>
-    </AuthProvider>
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route
+        path="/*"
+        element={
+          <Suspense fallback={<LoadingScreen message="Loading application…" />}>
+            <AuthenticatedApp />
+          </Suspense>
+        }
+      />
+    </Routes>
   );
 }
 

--- a/web/src/AuthenticatedApp.tsx
+++ b/web/src/AuthenticatedApp.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+
+import { LoadingScreen } from "./components/LoadingScreen";
+import { AuthProvider, useAuth } from "./context/AuthContext";
+import { ClientProvider } from "./context/ClientContext";
+import { AppLayout } from "./layouts/AppLayout";
+import { BillingReturnPage } from "./pages/BillingReturnPage";
+import { DashboardPage } from "./pages/DashboardPage";
+import { LoginPage } from "./pages/LoginPage";
+
+function ProtectedRoute({ children }: { children: ReactElement }): JSX.Element {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <LoadingScreen message="Checking authentication…" />;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+}
+
+export default function AuthenticatedApp(): JSX.Element {
+  return (
+    <AuthProvider>
+      <ClientProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/billing/success"
+              element={
+                <ProtectedRoute>
+                  <AppLayout>
+                    <BillingReturnPage status="success" />
+                  </AppLayout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/billing/cancel"
+              element={
+                <ProtectedRoute>
+                  <AppLayout>
+                    <BillingReturnPage status="cancel" />
+                  </AppLayout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/app"
+              element={
+                <ProtectedRoute>
+                  <AppLayout>
+                    <DashboardPage />
+                  </AppLayout>
+                </ProtectedRoute>
+              }
+            />
+            <Route path="*" element={<Navigate to="/app" replace />} />
+          </Routes>
+      </ClientProvider>
+    </AuthProvider>
+  );
+}

--- a/web/src/components/common/Badge.module.css
+++ b/web/src/components/common/Badge.module.css
@@ -1,0 +1,20 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--color-accent-muted);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-accent-border);
+}
+
+.badge img {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}

--- a/web/src/components/common/Badge.tsx
+++ b/web/src/components/common/Badge.tsx
@@ -1,0 +1,15 @@
+import styles from "./Badge.module.css";
+
+type BadgeProps = {
+  label: string;
+  iconSrc?: string;
+};
+
+export function Badge({ label, iconSrc }: BadgeProps): JSX.Element {
+  return (
+    <span className={styles.badge}>
+      {iconSrc ? <img src={iconSrc} alt="" aria-hidden="true" loading="lazy" decoding="async" /> : null}
+      {label}
+    </span>
+  );
+}

--- a/web/src/components/common/CtaButtons.module.css
+++ b/web/src/components/common/CtaButtons.module.css
@@ -1,0 +1,79 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: center;
+}
+
+.alignCenter {
+  justify-content: center;
+  text-align: center;
+}
+
+.alignRight {
+  justify-content: flex-end;
+}
+
+.alignLeft {
+  justify-content: flex-start;
+}
+
+.link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 10rem;
+  padding: 0.95rem 1.9rem;
+  border-radius: var(--radius-lg);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease, color 150ms ease;
+  border: 1px solid transparent;
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-soft);
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-strong) 100%);
+  color: var(--color-accent-contrast);
+  box-shadow: var(--shadow-elevated);
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+}
+
+.secondary {
+  background: var(--color-surface-subtle);
+  border-color: var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.secondary:hover {
+  border-color: var(--color-border-strong);
+  transform: translateY(-2px);
+}
+
+.link:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .link {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .container {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link {
+    transition: none;
+  }
+}

--- a/web/src/components/common/CtaButtons.tsx
+++ b/web/src/components/common/CtaButtons.tsx
@@ -1,0 +1,67 @@
+import { trackCtaClick } from "../../utils/analytics";
+import styles from "./CtaButtons.module.css";
+
+type CtaConfig = {
+  label: string;
+  href: string;
+  trackingId?: string;
+};
+
+type Align = "left" | "center" | "right";
+
+export type CtaButtonsProps = {
+  primary: CtaConfig;
+  secondary?: CtaConfig;
+  align?: Align;
+};
+
+const alignClassName: Record<Align, string> = {
+  left: styles.alignLeft,
+  center: styles.alignCenter,
+  right: styles.alignRight,
+};
+
+function emitCtaEvent(cta: CtaConfig, variant: "primary" | "secondary") {
+  if (!cta.trackingId) {
+    return;
+  }
+
+  trackCtaClick({
+    trackingId: cta.trackingId,
+    href: cta.href,
+    label: cta.label,
+    variant,
+    location: "home",
+  });
+}
+
+export function CtaButtons({ primary, secondary, align = "left" }: CtaButtonsProps): JSX.Element {
+  const containerClassName = `${styles.container} ${alignClassName[align]}`;
+
+  const handleClick = (cta: CtaConfig, variant: "primary" | "secondary") => () => {
+    emitCtaEvent(cta, variant);
+  };
+
+  return (
+    <div className={containerClassName}>
+      <a
+        className={`${styles.link} ${styles.primary}`}
+        href={primary.href}
+        onClick={handleClick(primary, "primary")}
+        data-tracking-id={primary.trackingId}
+      >
+        {primary.label}
+      </a>
+      {secondary ? (
+        <a
+          className={`${styles.link} ${styles.secondary}`}
+          href={secondary.href}
+          onClick={handleClick(secondary, "secondary")}
+          data-tracking-id={secondary.trackingId}
+        >
+          {secondary.label}
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/common/LogoRow.module.css
+++ b/web/src/components/common/LogoRow.module.css
@@ -1,0 +1,36 @@
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  opacity: 0.9;
+}
+
+.logoWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-translucent);
+  border: 1px solid var(--color-border-subtle);
+  min-height: 3rem;
+}
+
+.logoWrapper img {
+  max-height: 28px;
+  width: auto;
+  filter: grayscale(100%);
+  opacity: 0.9;
+}
+
+@media (max-width: 640px) {
+  .row {
+    justify-content: flex-start;
+  }
+
+  .logoWrapper {
+    padding: var(--space-xs) var(--space-md);
+  }
+}

--- a/web/src/components/common/LogoRow.tsx
+++ b/web/src/components/common/LogoRow.tsx
@@ -1,0 +1,26 @@
+import styles from "./LogoRow.module.css";
+
+type Logo = {
+  alt: string;
+  src: string;
+};
+
+export type LogoRowProps = {
+  logos: Logo[];
+};
+
+export function LogoRow({ logos }: LogoRowProps): JSX.Element | null {
+  if (!logos || logos.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.row} aria-label="Trusted by">
+      {logos.map((logo) => (
+        <div className={styles.logoWrapper} key={`${logo.src}-${logo.alt}`}>
+          <img src={logo.src} alt={logo.alt} loading="lazy" decoding="async" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/home/ArchDiagram.module.css
+++ b/web/src/components/home/ArchDiagram.module.css
@@ -1,0 +1,70 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  display: grid;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 3.6vw, 2.4rem);
+  color: var(--color-text-primary);
+}
+
+.diagram {
+  padding: var(--space-xl);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  box-shadow: var(--shadow-soft);
+}
+
+.diagram img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--radius-lg);
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  color: var(--color-text-secondary);
+}
+
+.legend li {
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-soft);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .diagram {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/ArchDiagram.tsx
+++ b/web/src/components/home/ArchDiagram.tsx
@@ -1,0 +1,43 @@
+import { useId } from "react";
+
+import styles from "./ArchDiagram.module.css";
+
+type ImageConfig = {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+};
+
+type ArchDiagramProps = {
+  headline: string;
+  image: ImageConfig;
+  legend: string[];
+};
+
+export function ArchDiagram({ headline, image, legend }: ArchDiagramProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.headline}>
+        {headline}
+      </h2>
+      <div className={styles.diagram}>
+        <img
+          src={image.src}
+          alt={image.alt}
+          width={image.width}
+          height={image.height}
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+      <ul className={styles.legend}>
+        {legend.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/components/home/FeaturesGrid.module.css
+++ b/web/src/components/home/FeaturesGrid.module.css
@@ -1,0 +1,102 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  color: var(--color-text-primary);
+  text-align: left;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-xl);
+}
+
+.card {
+  position: relative;
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.iconWrapper {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-soft-strong);
+  color: var(--color-text-primary);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.body {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.link {
+  margin-top: auto;
+  font-weight: 600;
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 960px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/FeaturesGrid.tsx
+++ b/web/src/components/home/FeaturesGrid.tsx
@@ -1,0 +1,91 @@
+import { useId } from "react";
+
+import styles from "./FeaturesGrid.module.css";
+
+type Feature = {
+  icon: string;
+  title: string;
+  body: string;
+  href: string;
+};
+
+export type FeaturesGridProps = {
+  headline: string;
+  features: Feature[];
+};
+
+const icons: Record<string, JSX.Element> = {
+  bolt: (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        d="M13 2 3 14h7l-1 8 10-12h-7z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.2"
+      />
+    </svg>
+  ),
+  shield: (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        d="M12 3 5 6v6c0 4.418 2.686 8.167 7 9 4.314-.833 7-4.582 7-9V6z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M9 12.5 11.25 15 15 9.75" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+  scales: (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path d="M12 3v18m5-14 4 7H13l4-7Zm-10 0 4 7H3l4-7Z" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+  layers: (
+    <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path
+        d="M12 4 4 8l8 4 8-4-8-4Zm0 8L4 8m8 4 8-4m-8 4v8m8-4-8 4-8-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+};
+
+function getIcon(name: string): JSX.Element {
+  return icons[name] ?? icons.layers;
+}
+
+export function FeaturesGrid({ headline, features }: FeaturesGridProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.headline}>
+        {headline}
+      </h2>
+      <div className={styles.grid}>
+        {features.map((feature) => (
+          <article className={styles.card} key={feature.title}>
+            <span className={styles.iconWrapper}>{getIcon(feature.icon)}</span>
+            <h3 className={styles.title}>{feature.title}</h3>
+            <p className={styles.body}>{feature.body}</p>
+            <a className={styles.link} href={feature.href}>
+              Learn more
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M4 12 12 4m0 0H6m6 0v6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+              </svg>
+            </a>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/FinalCtaBanner.module.css
+++ b/web/src/components/home/FinalCtaBanner.module.css
@@ -1,0 +1,60 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto var(--space-3xl);
+  padding: var(--space-2xl) var(--space-xl);
+}
+
+.banner {
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-accent-border);
+  background: radial-gradient(circle at top left, var(--color-accent-glow), transparent 45%),
+    var(--color-surface-overlay);
+  box-shadow: var(--shadow-elevated);
+  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  align-items: center;
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  color: var(--color-text-primary);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--color-text-secondary);
+  max-width: 640px;
+  font-size: 1.1rem;
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+
+  .banner {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .banner {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/FinalCtaBanner.tsx
+++ b/web/src/components/home/FinalCtaBanner.tsx
@@ -1,0 +1,33 @@
+import { useId } from "react";
+
+import { CtaButtons } from "../common/CtaButtons";
+import styles from "./FinalCtaBanner.module.css";
+
+type CtaConfig = {
+  label: string;
+  href: string;
+  trackingId: string;
+};
+
+type FinalCtaBannerProps = {
+  title: string;
+  subtitle: string;
+  primaryCta: CtaConfig;
+  secondaryCta: CtaConfig;
+};
+
+export function FinalCtaBanner({ title, subtitle, primaryCta, secondaryCta }: FinalCtaBannerProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <div className={styles.banner}>
+        <h2 id={headingId} className={styles.title}>
+          {title}
+        </h2>
+        <p className={styles.subtitle}>{subtitle}</p>
+        <CtaButtons primary={primaryCta} secondary={secondaryCta} align="center" />
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/Footer.module.css
+++ b/web/src/components/home/Footer.module.css
@@ -1,0 +1,88 @@
+.footer {
+  margin-top: var(--space-3xl);
+  background: var(--color-footer-background);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-2xl) var(--space-xl);
+}
+
+.inner {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.topRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-xl);
+}
+
+.columnTitle {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.linkList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.linkList a {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.contact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--color-text-secondary);
+}
+
+.contact a {
+  color: var(--color-accent);
+}
+
+.legal {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.legal a {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.bottomRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-sm);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 720px) {
+  .footer {
+    padding: var(--space-2xl) var(--space-lg);
+  }
+}

--- a/web/src/components/home/Footer.tsx
+++ b/web/src/components/home/Footer.tsx
@@ -1,0 +1,58 @@
+import styles from "./Footer.module.css";
+
+type FooterLink = {
+  label: string;
+  href: string;
+};
+
+type FooterColumn = {
+  title: string;
+  links: FooterLink[];
+};
+
+type FooterProps = {
+  company: string;
+  columns: FooterColumn[];
+  contact: FooterLink;
+  legal: FooterLink[];
+  copyright: string;
+};
+
+export function Footer({ company, columns, contact, legal, copyright }: FooterProps): JSX.Element {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.inner}>
+        <div className={styles.topRow}>
+          {columns.map((column) => (
+            <div key={column.title}>
+              <h3 className={styles.columnTitle}>{column.title}</h3>
+              <ul className={styles.linkList}>
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <a href={link.href}>{link.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          <div className={styles.contact}>
+            <h3 className={styles.columnTitle}>Contact</h3>
+            <span>Questions?</span>
+            <a href={contact.href}>{contact.label}</a>
+          </div>
+        </div>
+        <div className={styles.bottomRow}>
+          <span className={styles.brand}>{company}</span>
+          <div className={styles.legal}>
+            {legal.map((item) => (
+              <a key={item.label} href={item.href}>
+                {item.label}
+              </a>
+            ))}
+          </div>
+          <span>{copyright}</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/web/src/components/home/Hero.module.css
+++ b/web/src/components/home/Hero.module.css
@@ -1,0 +1,68 @@
+.hero {
+  position: relative;
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  padding: var(--space-3xl) var(--space-xl) var(--space-2xl);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.title {
+  font-size: clamp(2.75rem, 6vw, 3.75rem);
+  line-height: 1.08;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0 auto;
+  max-width: 780px;
+  font-size: clamp(1.125rem, 2.1vw, 1.4rem);
+  color: var(--color-text-secondary);
+}
+
+.backgroundGlow {
+  position: absolute;
+  inset: -20% -10% auto;
+  height: 420px;
+  pointer-events: none;
+  background: radial-gradient(circle at top, var(--color-accent-glow), transparent 65%),
+    radial-gradient(circle at 20% 40%, var(--color-indigo-soft), transparent 55%);
+  opacity: 0.8;
+  filter: blur(45px);
+  z-index: -1;
+}
+
+.trustCopy {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero {
+    animation: fadeInHero 180ms ease-out;
+  }
+}
+
+@keyframes fadeInHero {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/Hero.tsx
+++ b/web/src/components/home/Hero.tsx
@@ -1,0 +1,41 @@
+import { CtaButtons } from "../common/CtaButtons";
+import { LogoRow } from "../common/LogoRow";
+import styles from "./Hero.module.css";
+
+type CtaConfig = {
+  label: string;
+  href: string;
+  trackingId: string;
+};
+
+type Logo = {
+  alt: string;
+  src: string;
+};
+
+export type HeroProps = {
+  title: string;
+  subtitle: string;
+  primaryCta: CtaConfig;
+  secondaryCta: CtaConfig;
+  logos: Logo[];
+};
+
+export function Hero({ title, subtitle, primaryCta, secondaryCta, logos }: HeroProps): JSX.Element {
+  return (
+    <div className={styles.hero}>
+      <span className={styles.backgroundGlow} aria-hidden="true" />
+      <div className={styles.copy}>
+        <h1 className={styles.title}>{title}</h1>
+        <p className={styles.subtitle}>{subtitle}</p>
+      </div>
+      <CtaButtons primary={primaryCta} secondary={secondaryCta} align="center" />
+      {logos.length ? (
+        <div>
+          <p className={styles.trustCopy}>Trusted by forward-thinking data teams</p>
+          <LogoRow logos={logos} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/home/PricingPreview.module.css
+++ b/web/src/components/home/PricingPreview.module.css
@@ -1,0 +1,83 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 3.6vw, 2.4rem);
+  color: var(--color-text-primary);
+}
+
+.plans {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-lg);
+}
+
+.planCard {
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.planName {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.planSummary {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.startingAt {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.planLink {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.note {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .planCard {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/PricingPreview.tsx
+++ b/web/src/components/home/PricingPreview.tsx
@@ -1,0 +1,41 @@
+import { useId } from "react";
+
+import styles from "./PricingPreview.module.css";
+
+type Plan = {
+  name: string;
+  summary: string;
+  startingAt: string;
+  href: string;
+};
+
+type PricingPreviewProps = {
+  headline: string;
+  plans: Plan[];
+  note: string;
+};
+
+export function PricingPreview({ headline, plans, note }: PricingPreviewProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.headline}>
+        {headline}
+      </h2>
+      <div className={styles.plans}>
+        {plans.map((plan) => (
+          <article className={styles.planCard} key={plan.name}>
+            <h3 className={styles.planName}>{plan.name}</h3>
+            <p className={styles.planSummary}>{plan.summary}</p>
+            <span className={styles.startingAt}>Starting at {plan.startingAt}</span>
+            <a className={styles.planLink} href={plan.href}>
+              See plan details
+            </a>
+          </article>
+        ))}
+      </div>
+      <p className={styles.note}>{note}</p>
+    </section>
+  );
+}

--- a/web/src/components/home/ServerlessIcebergExplainer.module.css
+++ b/web/src/components/home/ServerlessIcebergExplainer.module.css
@@ -1,0 +1,94 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 3.6vw, 2.4rem);
+  color: var(--color-text-primary);
+}
+
+.content {
+  display: grid;
+  gap: var(--space-xl);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.paragraphs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  color: var(--color-text-secondary);
+  line-height: 1.65;
+  font-size: 1.05rem;
+}
+
+.bullets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.bulletItem {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.bulletItem::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0.35rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-muted));
+}
+
+.learnMore {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+@media (max-width: 960px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .section {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/ServerlessIcebergExplainer.tsx
+++ b/web/src/components/home/ServerlessIcebergExplainer.tsx
@@ -1,0 +1,44 @@
+import { useId } from "react";
+
+import styles from "./ServerlessIcebergExplainer.module.css";
+
+type ServerlessIcebergExplainerProps = {
+  headline: string;
+  paragraphs: string[];
+  bullets: string[];
+  learnMoreHref: string;
+};
+
+export function ServerlessIcebergExplainer({
+  headline,
+  paragraphs,
+  bullets,
+  learnMoreHref,
+}: ServerlessIcebergExplainerProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.headline}>
+        {headline}
+      </h2>
+      <div className={styles.content}>
+        <div className={styles.paragraphs}>
+          {paragraphs.map((paragraph) => (
+            <p key={paragraph}>{paragraph}</p>
+          ))}
+          <a className={styles.learnMore} href={learnMoreHref}>
+            Learn more in the docs
+          </a>
+        </div>
+        <ul className={styles.bullets}>
+          {bullets.map((bullet) => (
+            <li key={bullet} className={styles.bulletItem}>
+              {bullet}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/SocialProof.module.css
+++ b/web/src/components/home/SocialProof.module.css
@@ -1,0 +1,77 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 3.6vw, 2.4rem);
+  color: var(--color-text-primary);
+  text-align: left;
+}
+
+.testimonialCard {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: var(--space-xl);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.quote {
+  font-size: clamp(1.25rem, 3vw, 1.6rem);
+  line-height: 1.5;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.author {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+@media (max-width: 960px) {
+  .testimonialCard {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .testimonialCard {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/SocialProof.tsx
+++ b/web/src/components/home/SocialProof.tsx
@@ -1,0 +1,59 @@
+import { useId } from "react";
+
+import { Badge } from "../common/Badge";
+import { LogoRow } from "../common/LogoRow";
+import styles from "./SocialProof.module.css";
+
+type Testimonial = {
+  quote: string;
+  author: string;
+  role: string;
+  logo?: string;
+};
+
+type BadgeConfig = {
+  label: string;
+  iconSrc?: string;
+};
+
+type Logo = {
+  alt: string;
+  src: string;
+};
+
+type SocialProofProps = {
+  headline: string;
+  logos: Logo[];
+  testimonial: Testimonial;
+  badges: BadgeConfig[];
+};
+
+export function SocialProof({ headline, logos, testimonial, badges }: SocialProofProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <h2 id={headingId} className={styles.headline}>
+        {headline}
+      </h2>
+      <LogoRow logos={logos} />
+      <figure className={styles.testimonialCard}>
+        <blockquote className={styles.quote}>
+          “{testimonial.quote}”
+        </blockquote>
+        <figcaption className={styles.author}>
+          <strong>{testimonial.author}</strong>
+          <span>{testimonial.role}</span>
+          {testimonial.logo ? (
+            <img src={testimonial.logo} alt="" aria-hidden="true" loading="lazy" decoding="async" />
+          ) : null}
+        </figcaption>
+      </figure>
+      <div className={styles.badges}>
+        {badges.map((badge) => (
+          <Badge key={badge.label} label={badge.label} iconSrc={badge.iconSrc} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/ValueForManagers.module.css
+++ b/web/src/components/home/ValueForManagers.module.css
@@ -1,0 +1,75 @@
+.section {
+  max-width: var(--max-width-content);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-xl);
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  color: var(--color-text-primary);
+}
+
+.bullets {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.bulletCard {
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-soft);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-soft);
+}
+
+.bulletTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.bulletBody {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.kicker {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 720px) {
+  .section {
+    padding: var(--space-xl) var(--space-lg);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .section {
+    animation: fadeSection 140ms ease-out;
+  }
+}
+
+@keyframes fadeSection {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/components/home/ValueForManagers.tsx
+++ b/web/src/components/home/ValueForManagers.tsx
@@ -1,0 +1,37 @@
+import { useId } from "react";
+
+import styles from "./ValueForManagers.module.css";
+
+type Bullet = {
+  title: string;
+  body: string;
+};
+
+export type ValueForManagersProps = {
+  headline: string;
+  bullets: Bullet[];
+  kicker: string;
+};
+
+export function ValueForManagers({ headline, bullets, kicker }: ValueForManagersProps): JSX.Element {
+  const headingId = useId();
+
+  return (
+    <section className={styles.section} aria-labelledby={headingId}>
+      <div>
+        <h2 id={headingId} className={styles.headline}>
+          {headline}
+        </h2>
+      </div>
+      <div className={styles.bullets}>
+        {bullets.map((bullet) => (
+          <article className={styles.bulletCard} key={bullet.title}>
+            <h3 className={styles.bulletTitle}>{bullet.title}</h3>
+            <p className={styles.bulletBody}>{bullet.body}</p>
+          </article>
+        ))}
+      </div>
+      <p className={styles.kicker}>{kicker}</p>
+    </section>
+  );
+}

--- a/web/src/content/homePageContent.ts
+++ b/web/src/content/homePageContent.ts
@@ -1,0 +1,140 @@
+export const homePageContent = {
+  hero: {
+    title: "Serverless Lakehouse on Open Apache Iceberg",
+    subtitle: "Run analytics on your cloud storage with zero ops, predictable costs, and no vendor lock-in.",
+    primaryCta: { label: "Start free", href: "/signup", trackingId: "home_hero_start_free" },
+    secondaryCta: { label: "Book a demo", href: "/demo", trackingId: "home_hero_book_demo" },
+    logos: [{ alt: "Customer A", src: "/logos/customer-a.svg" }],
+  },
+  valueForManagers: {
+    headline: "Outcomes leaders care about",
+    bullets: [
+      { title: "Cut TCO", body: "Pay only when you query; scale-to-zero between workloads." },
+      { title: "Move faster", body: "Spin up data products in days, not quarters—no clusters to babysit." },
+      { title: "Own your data", body: "Open Iceberg tables on your object storage—portable across clouds." },
+      { title: "Reduce risk", body: "Fine-grained governance, time travel, and audited history by design." },
+    ],
+    kicker: "Built for modern data teams and the executives who sponsor them.",
+  },
+  features: {
+    headline: "What you get on day one",
+    features: [
+      {
+        icon: "bolt",
+        title: "Instant analytics",
+        body: "SQL over Iceberg with DuckDB; Trino/BigQuery/Snowflake optional later.",
+        href: "/features#analytics",
+      },
+      {
+        icon: "shield",
+        title: "Enterprise-grade isolation",
+        body: "Multi-tenant security with SSO and role-based access.",
+        href: "/features#security",
+      },
+      {
+        icon: "scales",
+        title: "Predictable pricing",
+        body: "Clear limits by plan; no surprise compute bills.",
+        href: "/pricing",
+      },
+      {
+        icon: "layers",
+        title: "Future-proof format",
+        body: "Schema evolution, ACID, and time travel on Apache Iceberg.",
+        href: "/features#iceberg",
+      },
+    ],
+  },
+  explainer: {
+    headline: "What is “serverless Apache Iceberg”?",
+    paragraphs: [
+      "Apache Iceberg is an open table format that adds reliability features—like ACID transactions, schema evolution, and time travel—on top of your cloud object storage.",
+      "Serverless means you don’t manage clusters—compute appears when you run a query, then scales to zero.",
+    ],
+    bullets: [
+      "Open standard: no vendor lock-in; works across GCS, S3, and Azure Blob.",
+      "Lower ops: no clusters to patch, right-size, or idle.",
+      "Governance built-in: snapshots and audited history for compliance.",
+    ],
+    learnMoreHref: "/docs/why-iceberg",
+  },
+  arch: {
+    headline: "Portable by design",
+    image: { src: "/img/arch.svg", alt: "High-level architecture", width: 1024, height: 640 },
+    legend: [
+      "Control plane: identity, entitlements, billing",
+      "Data plane: Iceberg tables on your object storage",
+      "Query engine: serverless, plug-in backends",
+    ],
+  },
+  socialProof: {
+    headline: "Trusted by data-led teams",
+    logos: [
+      { alt: "Logo 1", src: "/logos/1.svg" },
+      { alt: "Logo 2", src: "/logos/2.svg" },
+    ],
+    testimonial: {
+      quote: "We slashed analytics costs by 48% while shipping faster.",
+      author: "Jane Smith",
+      role: "VP Data, ExampleCo",
+    },
+    badges: [{ label: "SOC 2 in progress", iconSrc: "/icons/shield.svg" }],
+  },
+  pricing: {
+    headline: "Simple, transparent plans",
+    plans: [
+      { name: "Starter", summary: "For small teams getting started", startingAt: "$0", href: "/pricing#starter" },
+      { name: "Pro", summary: "For growing teams", startingAt: "$499/mo", href: "/pricing#pro" },
+    ],
+    note: "Enterprise pricing available—contact sales.",
+  },
+  finalCta: {
+    title: "Ready to try the open lakehouse?",
+    subtitle: "Start free in minutes or book a guided demo.",
+    primaryCta: { label: "Start free", href: "/signup", trackingId: "home_final_start_free" },
+    secondaryCta: { label: "Book a demo", href: "/demo", trackingId: "home_final_book_demo" },
+  },
+  seo: {
+    title: "Serverless Lakehouse on Apache Iceberg — Fast, Open, Cost-Efficient",
+    description:
+      "Run analytics on your cloud storage with an open Iceberg table format. No clusters, no lock-in, predictable pricing.",
+  },
+  footer: {
+    company: "Lakeview",
+    columns: [
+      {
+        title: "Product",
+        links: [
+          { label: "Features", href: "/features" },
+          { label: "Pricing", href: "/pricing" },
+          { label: "Docs", href: "/docs" },
+        ],
+      },
+      {
+        title: "Company",
+        links: [
+          { label: "About", href: "/about" },
+          { label: "Careers", href: "/careers" },
+          { label: "Blog", href: "/blog" },
+        ],
+      },
+      {
+        title: "Resources",
+        links: [
+          { label: "Security", href: "/security" },
+          { label: "Compliance", href: "/compliance" },
+          { label: "Support", href: "/support" },
+        ],
+      },
+    ],
+    contact: { label: "hello@lakeview.io", href: "mailto:hello@lakeview.io" },
+    legal: [
+      { label: "Privacy", href: "/legal/privacy" },
+      { label: "Terms", href: "/legal/terms" },
+      { label: "Status", href: "https://status.lakeview.io" },
+    ],
+    copyright: "© 2024 Lakeview Data, Inc. All rights reserved.",
+  },
+} as const;
+
+export type HomePageContent = typeof homePageContent;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,6 +5,47 @@
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   background-color: #020617;
   color: #e2e8f0;
+  --color-background: #020617;
+  --color-surface: rgba(15, 23, 42, 0.72);
+  --color-surface-subtle: rgba(15, 23, 42, 0.55);
+  --color-surface-soft: rgba(15, 23, 42, 0.45);
+  --color-surface-overlay: rgba(15, 23, 42, 0.6);
+  --color-surface-translucent: rgba(15, 23, 42, 0.35);
+  --color-surface-elevated: rgba(15, 23, 42, 0.92);
+  --color-border: rgba(148, 163, 184, 0.3);
+  --color-border-subtle: rgba(148, 163, 184, 0.2);
+  --color-border-strong: rgba(148, 163, 184, 0.45);
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5f5;
+  --color-text-muted: #94a3b8;
+  --color-accent: #38bdf8;
+  --color-accent-strong: #0ea5e9;
+  --color-accent-contrast: #0f172a;
+  --color-positive: #34d399;
+  --color-accent-glow: rgba(56, 189, 248, 0.35);
+  --color-accent-soft: rgba(56, 189, 248, 0.18);
+  --color-accent-soft-strong: rgba(56, 189, 248, 0.32);
+  --color-accent-muted: rgba(56, 189, 248, 0.15);
+  --color-accent-border: rgba(56, 189, 248, 0.3);
+  --color-indigo-soft: rgba(129, 140, 248, 0.25);
+  --color-focus-ring: rgba(56, 189, 248, 0.4);
+  --color-footer-background: rgba(2, 6, 23, 0.85);
+  --shadow-soft: 0 32px 60px -40px rgba(15, 23, 42, 0.8);
+  --shadow-ring: 0 0 0 1px rgba(148, 163, 184, 0.25);
+  --shadow-elevated: 0 30px 80px -40px rgba(37, 99, 235, 0.35), 0 18px 42px -32px rgba(15, 23, 42, 0.65);
+  --radius-sm: 12px;
+  --radius-md: 18px;
+  --radius-lg: 24px;
+  --radius-xl: 32px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  --space-3xl: 4.5rem;
+  --max-width-content: 1200px;
+  --max-width-wide: 1280px;
 }
 
 * {

--- a/web/src/pages/HomePage.module.css
+++ b/web/src/pages/HomePage.module.css
@@ -1,0 +1,59 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.heroHeader {
+  background: transparent;
+}
+
+.navbar {
+  max-width: var(--max-width-wide);
+  margin: 0 auto;
+  padding: var(--space-md) var(--space-xl);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.navLinks a {
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xl);
+  padding-bottom: var(--space-3xl);
+}
+
+@media (max-width: 720px) {
+  .navbar {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: var(--space-md) var(--space-lg);
+  }
+
+  .navLinks {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/web/src/pages/HomePage.tsx
+++ b/web/src/pages/HomePage.tsx
@@ -1,0 +1,131 @@
+import { useEffect } from "react";
+
+import { ArchDiagram } from "../components/home/ArchDiagram";
+import { FinalCtaBanner } from "../components/home/FinalCtaBanner";
+import { Footer } from "../components/home/Footer";
+import { FeaturesGrid } from "../components/home/FeaturesGrid";
+import { Hero } from "../components/home/Hero";
+import { PricingPreview } from "../components/home/PricingPreview";
+import { ServerlessIcebergExplainer } from "../components/home/ServerlessIcebergExplainer";
+import { SocialProof } from "../components/home/SocialProof";
+import { ValueForManagers } from "../components/home/ValueForManagers";
+import { homePageContent } from "../content/homePageContent";
+import styles from "./HomePage.module.css";
+
+type MetaCleanup = () => void;
+
+function setMetaTag(attribute: "name" | "property", key: string, value: string): MetaCleanup {
+  const head = document.head;
+  let tag = head.querySelector(`meta[${attribute}="${key}"]`) as HTMLMetaElement | null;
+  let created = false;
+  const previous = tag?.getAttribute("content") ?? null;
+
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.setAttribute(attribute, key);
+    head.appendChild(tag);
+    created = true;
+  }
+
+  tag.setAttribute("content", value);
+
+  return () => {
+    if (!tag) {
+      return;
+    }
+
+    if (created) {
+      tag.remove();
+    } else if (previous !== null) {
+      tag.setAttribute("content", previous);
+    }
+  };
+}
+
+function setCanonical(url: string): [HTMLLinkElement | null, boolean, string] {
+  const head = document.head;
+  let link = head.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+  let created = false;
+  const previous = link?.getAttribute("href") ?? "";
+
+  if (!link) {
+    link = document.createElement("link");
+    link.setAttribute("rel", "canonical");
+    head.appendChild(link);
+    created = true;
+  }
+
+  link.setAttribute("href", url);
+  return [link, created, previous];
+}
+
+export function HomePage(): JSX.Element {
+  const { hero, valueForManagers, features, explainer, arch, socialProof, pricing, finalCta, footer, seo } =
+    homePageContent;
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const previousTitle = document.title;
+    document.title = seo.title;
+
+    const cleanups: MetaCleanup[] = [];
+    cleanups.push(setMetaTag("name", "description", seo.description));
+    cleanups.push(setMetaTag("property", "og:title", seo.title));
+    cleanups.push(setMetaTag("property", "og:description", seo.description));
+    const canonicalUrl = `${window.location.origin}/`;
+    cleanups.push(setMetaTag("property", "og:url", canonicalUrl));
+    const heroImageUrl = new URL(arch.image.src, window.location.origin).toString();
+    cleanups.push(setMetaTag("property", "og:image", heroImageUrl));
+    cleanups.push(setMetaTag("name", "twitter:card", "summary_large_image"));
+    cleanups.push(setMetaTag("name", "twitter:title", seo.title));
+    cleanups.push(setMetaTag("name", "twitter:description", seo.description));
+    cleanups.push(setMetaTag("name", "twitter:image", heroImageUrl));
+
+    const [canonicalTag, created, previousCanonical] = setCanonical(canonicalUrl);
+
+    return () => {
+      document.title = previousTitle;
+      cleanups.forEach((cleanup) => cleanup());
+      if (canonicalTag) {
+        if (created) {
+          canonicalTag.remove();
+        } else {
+          canonicalTag.setAttribute("href", previousCanonical);
+        }
+      }
+    };
+  }, [arch.image.src, seo.description, seo.title]);
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.heroHeader}>
+        <nav className={styles.navbar} aria-label="Primary">
+          <a className={styles.brand} href="/">
+            {footer.company}
+          </a>
+          <div className={styles.navLinks}>
+            <a href="/pricing">Pricing</a>
+            <a href="/docs">Docs</a>
+            <a href="/login">Sign in</a>
+          </div>
+        </nav>
+        <Hero {...hero} />
+      </header>
+      <main className={styles.main}>
+        <ValueForManagers {...valueForManagers} />
+        <FeaturesGrid {...features} />
+        <ServerlessIcebergExplainer {...explainer} />
+        <ArchDiagram {...arch} />
+        <SocialProof {...socialProof} />
+        <PricingPreview {...pricing} />
+        <FinalCtaBanner {...finalCta} />
+      </main>
+      <Footer {...footer} />
+    </div>
+  );
+}
+
+export default HomePage;

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -1,0 +1,35 @@
+export type CtaPayload = {
+  trackingId: string;
+  href: string;
+  label: string;
+  location: string;
+  variant: "primary" | "secondary";
+};
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>;
+  }
+}
+
+export function trackCtaClick(payload: CtaPayload): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const eventPayload = {
+    event: "cta_click",
+    ...payload,
+    timestamp: Date.now(),
+  } as const;
+
+  window.dataLayer?.push(eventPayload);
+  if (typeof window.dispatchEvent === "function") {
+    window.dispatchEvent(new CustomEvent("cta_click", { detail: eventPayload }));
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console -- surface analytics payload during development for verification
+    console.debug("CTA click", eventPayload);
+  }
+}


### PR DESCRIPTION
## Summary
- add a marketing-focused home page composed of dedicated hero, value, feature, explainer, architecture, social proof, pricing, and CTA sections
- centralize all copy and assets in a single content configuration and wire CTA analytics tracking
- refactor routing to load the marketing experience at `/` while lazy-loading the authenticated application bundle

## Testing
- npm run lint *(fails: ESLint configuration missing in project)*

------
https://chatgpt.com/codex/tasks/task_b_68ca19f7ea848332885f19357be5bb4c